### PR TITLE
fix multichannel float input-type for dot

### DIFF
--- a/CppStackerBox.cpp
+++ b/CppStackerBox.cpp
@@ -510,8 +510,9 @@ bool CppStackerBox::generateCode(GenerateCodeContext& context) {
       dataType = EDT_Float;
       if (context.code) {
         CppStackerBox& param1 = (CppStackerBox&)*context.params[1];
-        int32 param0VIndex = upgradeTypeIfNeeded(context, dataType, param0);
-        int32 param1VIndex = upgradeTypeIfNeeded(context, dataType, param1);
+        EDataType max_input_type = std::max(param0.dataType, param1.dataType);
+        int32 param0VIndex = upgradeTypeIfNeeded(context, max_input_type, param0);
+        int32 param1VIndex = upgradeTypeIfNeeded(context, max_input_type, param1);
         sprintf_s(str, sizeof(str), "%s%s v%d = dot(v%d, v%d); // %s\n",
           context.indentationStr,
           getGLSLTypeName(dataType),


### PR DESCRIPTION
fix vector input type for dot product float2, etc...

minimal repro of bug/check for fix:

{"magic":"Stacker","version":1,"stackerBoxes":[{"type":"CppStackerBox","rect":[7,9,6,2],"nodeType":21,"name":"","dataType":2},{"type":"CppStackerBox","rect":[7,7,10,1],"nodeType":13,"name":"Dot","dataType":2},{"type":"CppStackerBox","rect":[7,8,5,1],"nodeType":10,"name":"Frac","dataType":2},{"type":"CppStackerBox","rect":[7,6,5,1],"nodeType":20,"name":"ScreenUV","dataType":3},{"type":"CppStackerBoxConstant","rect":[13,6,5,1],"constantType":1,"valueX":12.8100004196167,"valueY":78.51200103759766,"valueZ":0,"valueW":0,"minSlider":0,"maxSlider":100}]}